### PR TITLE
Implement Seeders, API Endpoints, and Data Filtering for Subject Management

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Student;
+use Illuminate\Support\Facades\Validator;
+
+class StudentController extends Controller
+{   
+    //getting record
+    public function index(Request $request)
+    {
+        $query = Student::query();
+
+        // Filtering
+        if ($request->has('sort')) {
+            $query->orderBy($request->sort);
+        }
+        if ($request->has('search')) {
+            $query->where('firstname', 'like', "%{$request->search}%")
+                  ->orWhere('lastname', 'like', "%{$request->search}%");
+        }
+        if ($request->has('year')) {
+            $query->where('year', $request->year);
+        }
+        if ($request->has('course')) {
+            $query->where('course', $request->course);
+        }
+        if ($request->has('section')) {
+            $query->where('section', $request->section);
+        }
+
+        // Field filtering separate using comma.
+        $fields = $request->has('fields') ? explode(',', $request->fields) : ['*'];
+
+        // limiting and offset
+        $limit = $request->limit ?? 10;
+        $offset = $request->offset ?? 0;
+
+        // return response ageyn
+        return $query->select($fields)->offset($offset)->limit($limit)->get();
+    }
+
+    //getting specific id/single record
+    public function show($id)
+    { 
+        $student = Student::find($id);
+        return $student ? response()->json($student) : response()->json(['error' => 'Student not found'], 404);
+    }
+
+    //posting
+    public function add(Request $request)
+    {   
+        //validation
+        $validator = Validator::make($request->all(), [
+            'firstname' => 'required|string|max:255',
+            'lastname' => 'required|string|max:255',
+            'birthdate' => 'required|date',
+            'sex' => 'required|in:MALE,FEMALE',
+            'address' => 'required|string|max:255',
+            'year' => 'required|integer|min:1',
+            'course' => 'required|string|max:255',
+            'section' => 'required|string|max:255'
+        ]);
+
+        //if fail return error
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+        // otherwise return the recently added record
+        $student = Student::create($validator->validated());
+        return response()->json($student, 201);
+    }
+
+    //patching
+    public function update(Request $request, $id)
+    {
+        $student = Student::find($id);
+        
+        //if no such student exists return error
+        if (!$student) {
+            return response()->json(['error' => 'Student not found'], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'firstname' => 'string|max:255',
+            'lastname' => 'string|max:255',
+            'birthdate' => 'date',
+            'sex' => 'in:MALE,FEMALE',
+            'address' => 'string|max:255',
+            'year' => 'integer|min:1',
+            'course' => 'string|max:255',
+            'section' => 'string|max:255'
+        ]);
+
+        //if validator is not met return the error
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        //return recently updated record
+        $student->update($validator->validated());
+        return response()->json($student);
+    }
+
+    
+}
+

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Subject;
+use App\Models\Student;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class SubjectController extends Controller
+{
+    public function index(Request $request, $studentId)
+    {
+        $query = Subject::where('student_id', $studentId);
+
+        // Filtering based on query parameters
+        if ($request->has('sort')) {
+            $query->orderBy($request->sort);
+        }
+        if ($request->has('search')) {
+            $query->where('name', 'like', "%{$request->search}%")
+                  ->orWhere('description', 'like', "%{$request->search}%");
+        }
+        if ($request->has('remarks')) {
+            $query->where('remarks', $request->remarks);
+        }
+
+        // Select specific fields
+        $fields = $request->has('fields') ? explode(',', $request->fields) : ['*'];
+
+        // Pagination settings
+        $limit = $request->get('limit', 10);
+        $offset = $request->get('offset', 0);
+
+        // Retrieve and return the filtered records
+        return $query->select($fields)->offset($offset)->limit($limit)->get();
+    }
+
+    public function add(Request $request, $studentId)
+    {
+        $validator = Validator::make($request->all(), [
+            'subject_code' => 'required|string|max:255',
+            'name' => 'required|string|max:255',
+            'description' => 'string|nullable',
+            'instructor' => 'required|string|max:255',
+            'schedule' => 'required|string|max:255',
+            'grades.prelims' => 'required|numeric',
+            'grades.midterms' => 'required|numeric',
+            'grades.pre_finals' => 'required|numeric',
+            'grades.finals' => 'required|numeric',
+            'date_taken' => 'required|date',
+            'student_id' => 'required|exists:students,id'
+        ]);
+    
+        if (!$validator->fails()) {
+            $validatedData = $validator->validated();
+            $average_grade = array_sum($validatedData['grades']) / count($validatedData['grades']);
+            $remarks = $average_grade <= 3.0 ? 'PASSED' : 'FAILED';
+        
+            // Create and save the new subject
+            $subject = new Subject([
+                'subject_code' => $validatedData['subject_code'],
+                'name' => $validatedData['name'],
+                'description' => $validatedData['description'],
+                'instructor' => $validatedData['instructor'],
+                'schedule' => $validatedData['schedule'],
+                'grades' => $validatedData['grades'],
+                'average_grade' => $average_grade,
+                'remarks' => $remarks,
+                'date_taken' => $validatedData['date_taken'],
+                'student_id' => $validatedData['student_id'],
+            ]);
+            $subject->save();
+        
+            return response()->json($subject, 201);
+        } else {
+            return response()->json($validator->errors(), 422);
+        }
+    }
+
+    public function show($studentId, $subjectId)
+    {
+        $subject = Subject::where('student_id', $studentId)->where('id', $subjectId)->first();
+        if (!$subject) {
+            return response()->json(['error' => 'Subject not found'], 404);
+        }
+        return response()->json($subject);
+    }
+
+    public function update(Request $request, $id, $subjectId)
+    {
+    $subject = Subject::find($subjectId);
+    if (!$subject) {
+        return response()->json(['error' => 'Subject not found'], 404);
+    }
+
+    $validator = Validator::make($request->all(), [
+        'subject_code' => 'string|max:255',
+        'name' => 'string|max:255',
+        'description' => 'string|nullable',
+        'instructor' => 'string|max:255',
+        'schedule' => 'string|max:255',
+        'grades.prelims' => 'numeric',
+        'grades.midterms' => 'numeric',
+        'grades.pre_finals' => 'numeric',
+        'grades.finals' => 'numeric',
+        'date_taken' => 'date',
+        'student_id' => 'exists:students,id'
+    ]);
+
+    if ($validator->fails()) {
+        return response()->json($validator->errors(), 422);
+    }
+
+    // Collect
+    $validatedData = $validator->validated();
+
+    // If grades are updated, recalculate the average grade and remarks
+    if (isset($validatedData['grades'])) {
+        $average_grade = array_sum($validatedData['grades']) / count($validatedData['grades']);
+        $remarks = $average_grade <= 3.0 ? 'PASSED' : 'FAILED';
+        $validatedData['average_grade'] = $average_grade;
+        $validatedData['remarks'] = $remarks;
+    }
+
+    // Update the subject with new record
+    $subject->update($validatedData);
+
+    return response()->json($subject);
+}
+}

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Student extends Model
+{   
+    //allow these fields to be fillable
+    protected $fillable = [
+        'firstname',
+        'lastname',
+        'birthdate',
+        'sex',
+        'address',
+        'year',
+        'course',
+        'section',
+    ];
+
+}

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Student extends Model
 {   
+    use HasFactory;
+
     //allow these fields to be fillable
     protected $fillable = [
         'firstname',
@@ -17,5 +20,11 @@ class Student extends Model
         'course',
         'section',
     ];
+
+    //associates this to subject
+    public function subjects()
+    {
+        return $this->hasMany(Subject::class);
+    }
 
 }

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Subject extends Model
+{
+    use HasFactory;
+    
+    protected $fillable = [
+        'subject_code',
+        'name',
+        'description',
+        'instructor',
+        'schedule',
+        'grades',
+        'average_grade',
+        'remarks',
+        'date_taken',
+        'student_id'
+    ];
+
+    protected $casts = [
+        'grades' => 'array',  // json first before passing to db
+    ];
+
+    public function student()
+{
+    return $this->belongsTo(Student::class);
+}
+
+}

--- a/database/factories/StudentFactory.php
+++ b/database/factories/StudentFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Student>
+ */
+class StudentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'firstname' => $this->faker->firstName,
+            'lastname' => $this->faker->lastName,
+            'birthdate' => $this->faker->date($format = 'Y-m-d', $max = '2003-12-31'),
+            'sex' => $this->faker->randomElement(['MALE', 'FEMALE']),
+            'address' => $this->faker->address,
+            'year' => $this->faker->numberBetween(1, 4),
+            'course' => $this->faker->randomElement(['BSIT', 'BSCS', 'BSIS']),
+            'section' => $this->faker->randomElement(['A', 'B', 'C', 'D']),
+        ];
+    }
+}

--- a/database/factories/SubjectFactory.php
+++ b/database/factories/SubjectFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Subject>
+ */
+class SubjectFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        //variable holders with correct usage of randomFloat
+        $prelims = $this->faker->randomFloat(2, 1, 4);
+        $midterms= $this->faker->randomFloat(2, 1, 4);
+        $pre_finals = $this->faker->randomFloat(2, 1, 4);
+        $finals = $this->faker->randomFloat(2, 1, 4);
+
+        //average
+        $average = ($prelims + $midterms + $pre_finals + $finals) / 4;
+        $average = round($average, 2);
+        //remarks logic
+        $remarks = $average <= 3.0 ? 'PASSED' : 'FAILED';
+
+        return [
+            'subject_code' => $this->faker->regexify('[A-Z]{3}-[0-9]{3}'),
+            'name' => $this->faker->sentence(3),
+            'description' => $this->faker->text(200),
+            'instructor' => $this->faker->name,
+            'schedule' => $this->faker->randomElement(['MWF 9AM-11AM', 'TH 1PM-4PM', 'MW 7AM-10AM']),
+            'grades' => json_encode([
+                'prelims' => $prelims,
+                'midterms' => $midterms,
+                'pre_finals' => $pre_finals,
+                'finals' => $finals,
+            ]),
+            'average_grade' => $average,
+            'remarks' => $remarks,
+            'date_taken' => $this->faker->date,
+        ];
+    }
+}

--- a/database/migrations/2024_05_23_130659_create_students_table.php
+++ b/database/migrations/2024_05_23_130659_create_students_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('students', function (Blueprint $table) {
+            $table->id();
+            $table->string('firstname');
+            $table->string('lastname');
+            $table->date('birthdate');
+            $table->enum('sex', ['MALE', 'FEMALE']);
+            $table->string('address');
+            $table->unsignedInteger('year');
+            $table->string('course');
+            $table->string('section');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('students');
+    }
+};

--- a/database/migrations/2024_05_23_141110_create_subjects_table.php
+++ b/database/migrations/2024_05_23_141110_create_subjects_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('subjects', function (Blueprint $table) {
+            $table->id();
+            $table->string('subject_code');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('instructor');
+            $table->string('schedule');
+            $table->json('grades');
+            $table->double('average_grade');
+            $table->string('remarks');
+            $table->date('date_taken');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subjects');
+    }
+};

--- a/database/migrations/2024_05_23_152934_add_student_id_to_subjects_table.php
+++ b/database/migrations/2024_05_23_152934_add_student_id_to_subjects_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->unsignedBigInteger('student_id')->after('id');
+            $table->foreign('student_id')->references('id')->on('students')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/seeders/StudentsSeeder.php
+++ b/database/seeders/StudentsSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class StudentsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        \App\Models\Student::factory(10)->create();
+    }
+}

--- a/database/seeders/SubjectSeeder.php
+++ b/database/seeders/SubjectSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Student;
+use App\Models\Subject;
+
+class SubjectSeeder extends Seeder
+{
+    public function run()
+    {
+        Student::all()->each(function ($student) {
+            Subject::factory()->count(8)->create([
+                'student_id' => $student->id
+            ]);
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Http\Controllers\StudentController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
+Route::get('/students', [StudentController::class, 'index']);
+Route::get('/students/{id}', [StudentController::class, 'show']);
+Route::post('/students', [StudentController::class, 'add']);
+Route::patch('/students/{id}', [StudentController::class, 'update']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,20 @@
 <?php
 
 use App\Http\Controllers\StudentController;
+use App\Http\Controllers\SubjectController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+
+//routes for students
 
 Route::get('/students', [StudentController::class, 'index']);
 Route::get('/students/{id}', [StudentController::class, 'show']);
 Route::post('/students', [StudentController::class, 'add']);
 Route::patch('/students/{id}', [StudentController::class, 'update']);
+
+//routes for subs
+
+Route::get('/students/{id}/subjects', [SubjectController::class, 'index']);
+Route::post('/students/{id}/subjects', [SubjectController::class, 'add']);
+Route::get('/students/{id}/subjects/{subject_id}', [SubjectController::class, 'show']);
+Route::patch('/students/{id}/subjects/{subject_id}', [SubjectController::class, 'update']);


### PR DESCRIPTION
This pull request introduces new features in the former student management, in this branch we added the following:

Seeders: created a fake record with the following fields such as 'subject_code', 'name', 'description', 'instructor', 'schedule','grades', 
              'average_grade', 'remarks', 'date_taken', 'student_id'.

Endpoints: Created an api endpoints for the following httprequest methods: Get, Post, and Patch.

Filtering: Added query parameters for the GET endpoint like sort, search, limit, offset, fields, remarks.

this allows the user to add view and edit the subjects of the student they want to interact with. this also is a combination of the two commits for subject and student management.

From: Bulilan, Ianne Carl Z. - BSIT 3B